### PR TITLE
Support grpc < 1.21.0

### DIFF
--- a/grpc_mock.gemspec
+++ b/grpc_mock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'grpc', '>= 1.12.0', '< 1.19.0'
+  spec.add_dependency 'grpc', '>= 1.12.0', '< 1.21.0'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'grpc-tools'


### PR DESCRIPTION
This adds supports for grpc 1.20.0 that was released last month. https://rubygems.org/gems/grpc/versions/1.20.0-x86_64-linux