### PR TITLE
unlock to prevent month to month releasees

### DIFF
--- a/grpc_mock.gemspec
+++ b/grpc_mock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'grpc', '>= 1.12.0', '< 1.22.0'
+  spec.add_dependency 'grpc', '>= 1.12.0', '< 2'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'grpc-tools'


### PR DESCRIPTION
thought was preventing requiring a gem release every few months (since `grpc` seems to have frequent if irregular releases).