### PR TITLE
Support to_return with block

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ client.hello(Hello::HelloRequest.new(msg: 'hello')) # => send a request to serve
 client client.hello(Hello::HelloRequest.new(msg: 'hi'))    # => Hello::HelloResponse.new(msg: 'test') (without any requests to server)
 ```
 
+### Responding dynamically to the stubbed requests
+
+```ruby
+GrpcMock.stub_request("/hello.hello/Hello").to_return do |req|
+  Hello::HelloResponse.new(msg: "#{req.msg} too")
+end
+
+client = Hello::Hello::Stub.new('localhost:8000', :this_channel_is_insecure)
+client.hello(Hello::HelloRequest.new(msg: 'hi'))    # => Hello::HelloResponse.new(msg: 'hi too')
+```
+
 ### Real requests to network can be allowed or disabled
 
 ```ruby

--- a/lib/grpc_mock/grpc_stub_adapter.rb
+++ b/lib/grpc_mock/grpc_stub_adapter.rb
@@ -15,7 +15,7 @@ module GrpcMock
 
         mock = GrpcMock.stub_registry.response_for_request(method, request)
         if mock
-          mock.call(request)
+          mock.evaluate(request)
         elsif GrpcMock.config.allow_net_connect
           super
         else
@@ -32,7 +32,7 @@ module GrpcMock
         r = requests.to_a       # FIXME: this may not work
         mock = GrpcMock.stub_registry.response_for_request(method, r)
         if mock
-          mock.call(r)
+          mock.evaluate(r)
         elsif GrpcMock.config.allow_net_connect
           super
         else
@@ -47,7 +47,7 @@ module GrpcMock
 
         mock = GrpcMock.stub_registry.response_for_request(method, request)
         if mock
-          mock.call(request)
+          mock.evaluate(request)
         elsif GrpcMock.config.allow_net_connect
           super
         else
@@ -63,7 +63,7 @@ module GrpcMock
         r = requests.to_a       # FIXME: this may not work
         mock = GrpcMock.stub_registry.response_for_request(method, r)
         if mock
-          mock.call(r)
+          mock.evaluate(r)
         elsif GrpcMock.config.allow_net_connect
           super
         else

--- a/lib/grpc_mock/grpc_stub_adapter.rb
+++ b/lib/grpc_mock/grpc_stub_adapter.rb
@@ -15,7 +15,7 @@ module GrpcMock
 
         mock = GrpcMock.stub_registry.response_for_request(method, request)
         if mock
-          mock.evaluate
+          mock.call(request)
         elsif GrpcMock.config.allow_net_connect
           super
         else
@@ -32,7 +32,7 @@ module GrpcMock
         r = requests.to_a       # FIXME: this may not work
         mock = GrpcMock.stub_registry.response_for_request(method, r)
         if mock
-          mock.evaluate
+          mock.call(r)
         elsif GrpcMock.config.allow_net_connect
           super
         else
@@ -47,7 +47,7 @@ module GrpcMock
 
         mock = GrpcMock.stub_registry.response_for_request(method, request)
         if mock
-          mock.evaluate
+          mock.call(request)
         elsif GrpcMock.config.allow_net_connect
           super
         else
@@ -63,7 +63,7 @@ module GrpcMock
         r = requests.to_a       # FIXME: this may not work
         mock = GrpcMock.stub_registry.response_for_request(method, r)
         if mock
-          mock.evaluate
+          mock.call(r)
         elsif GrpcMock.config.allow_net_connect
           super
         else

--- a/lib/grpc_mock/request_stub.rb
+++ b/lib/grpc_mock/request_stub.rb
@@ -20,7 +20,7 @@ module GrpcMock
 
     def to_return(*values, &block)
       responses = [*values].flatten.map { |v| Response::Value.new(v) }
-      responses << block if block
+      responses << Response::BlockValue.new(block) if block
       @response_sequence << GrpcMock::ResponsesSequence.new(responses)
       self
     end

--- a/lib/grpc_mock/request_stub.rb
+++ b/lib/grpc_mock/request_stub.rb
@@ -18,8 +18,9 @@ module GrpcMock
       self
     end
 
-    def to_return(*values)
+    def to_return(*values, &block)
       responses = [*values].flatten.map { |v| Response::Value.new(v) }
+      responses << block if block
       @response_sequence << GrpcMock::ResponsesSequence.new(responses)
       self
     end

--- a/lib/grpc_mock/response.rb
+++ b/lib/grpc_mock/response.rb
@@ -16,7 +16,7 @@ module GrpcMock
                      end
       end
 
-      def call(_request)
+      def evaluate(_request = nil)
         raise @exception.dup
       end
     end
@@ -26,8 +26,18 @@ module GrpcMock
         @value = value
       end
 
-      def call(_request)
+      def evaluate(_request = nil)
         @value.dup
+      end
+    end
+
+    class BlockValue
+      def initialize(block)
+        @block = block
+      end
+
+      def evaluate(request)
+        @block.call(request)
       end
     end
   end

--- a/lib/grpc_mock/response.rb
+++ b/lib/grpc_mock/response.rb
@@ -16,7 +16,7 @@ module GrpcMock
                      end
       end
 
-      def evaluate
+      def call(_request)
         raise @exception.dup
       end
     end
@@ -26,7 +26,7 @@ module GrpcMock
         @value = value
       end
 
-      def evaluate
+      def call(_request)
         @value.dup
       end
     end

--- a/spec/grpc_mock/request_stub_spec.rb
+++ b/spec/grpc_mock/request_stub_spec.rb
@@ -19,34 +19,34 @@ RSpec.describe GrpcMock::RequestStub do
 
     it 'returns response' do
       stub_request.to_return(value1)
-      expect(stub_request.response.call(request1)).to eq(value1)
+      expect(stub_request.response.evaluate(request1)).to eq(value1)
     end
 
     it 'raises exception' do
       stub_request.to_raise(exception)
-      expect { stub_request.response.call(request1) }.to raise_error(StandardError)
+      expect { stub_request.response.evaluate(request1) }.to raise_error(StandardError)
     end
 
     it 'returns responses in a sequence passed as array' do
       stub_request.to_return(value1, value2)
-      expect(stub_request.response.call(request1)).to eq(value1)
-      expect(stub_request.response.call(request1)).to eq(value2)
+      expect(stub_request.response.evaluate(request1)).to eq(value1)
+      expect(stub_request.response.evaluate(request1)).to eq(value2)
     end
 
     it 'returns responses in a sequence passed as array with multiple to_return calling' do
       stub_request.to_return(value1, value2)
       stub_request.to_return(value3)
-      expect(stub_request.response.call(request1)).to eq(value1)
-      expect(stub_request.response.call(request1)).to eq(value2)
-      expect(stub_request.response.call(request1)).to eq(value3)
+      expect(stub_request.response.evaluate(request1)).to eq(value1)
+      expect(stub_request.response.evaluate(request1)).to eq(value2)
+      expect(stub_request.response.evaluate(request1)).to eq(value3)
     end
 
     it 'repeats returning last response' do
       stub_request.to_return(value1, value2)
-      expect(stub_request.response.call(request1)).to eq(value1)
-      expect(stub_request.response.call(request1)).to eq(value2)
-      expect(stub_request.response.call(request1)).to eq(value2)
-      expect(stub_request.response.call(request1)).to eq(value2)
+      expect(stub_request.response.evaluate(request1)).to eq(value1)
+      expect(stub_request.response.evaluate(request1)).to eq(value2)
+      expect(stub_request.response.evaluate(request1)).to eq(value2)
+      expect(stub_request.response.evaluate(request1)).to eq(value2)
     end
 
     it 'repeats running last response' do
@@ -57,11 +57,11 @@ RSpec.describe GrpcMock::RequestStub do
         else; value3
         end
       end
-      expect(stub_request.response.call(request2)).to eq(value1)
-      expect(stub_request.response.call(request1)).to eq(value2)
-      expect(stub_request.response.call(request2)).to eq(value2)
-      expect(stub_request.response.call(request1)).to eq(value1)
-      expect(stub_request.response.call(request2)).to eq(value2)
+      expect(stub_request.response.evaluate(request2)).to eq(value1)
+      expect(stub_request.response.evaluate(request1)).to eq(value2)
+      expect(stub_request.response.evaluate(request2)).to eq(value2)
+      expect(stub_request.response.evaluate(request1)).to eq(value1)
+      expect(stub_request.response.evaluate(request2)).to eq(value2)
     end
 
     context 'when not calling #to_return' do

--- a/spec/grpc_mock/request_stub_spec.rb
+++ b/spec/grpc_mock/request_stub_spec.rb
@@ -11,40 +11,57 @@ RSpec.describe GrpcMock::RequestStub do
 
   describe '#response' do
     let(:exception) { StandardError.new }
+    let(:request1) { :request_1 }
+    let(:request2) { :request_2 }
     let(:value1) { :response_1 }
     let(:value2) { :response_2 }
     let(:value3) { :response_3 }
 
     it 'returns response' do
       stub_request.to_return(value1)
-      expect(stub_request.response.evaluate).to eq(value1)
+      expect(stub_request.response.call(request1)).to eq(value1)
     end
 
     it 'raises exception' do
       stub_request.to_raise(exception)
-      expect { stub_request.response.evaluate }.to raise_error(StandardError)
+      expect { stub_request.response.call(request1) }.to raise_error(StandardError)
     end
 
     it 'returns responses in a sequence passed as array' do
       stub_request.to_return(value1, value2)
-      expect(stub_request.response.evaluate).to eq(value1)
-      expect(stub_request.response.evaluate).to eq(value2)
+      expect(stub_request.response.call(request1)).to eq(value1)
+      expect(stub_request.response.call(request1)).to eq(value2)
     end
 
     it 'returns responses in a sequence passed as array with multiple to_return calling' do
       stub_request.to_return(value1, value2)
       stub_request.to_return(value3)
-      expect(stub_request.response.evaluate).to eq(value1)
-      expect(stub_request.response.evaluate).to eq(value2)
-      expect(stub_request.response.evaluate).to eq(value3)
+      expect(stub_request.response.call(request1)).to eq(value1)
+      expect(stub_request.response.call(request1)).to eq(value2)
+      expect(stub_request.response.call(request1)).to eq(value3)
     end
 
     it 'repeats returning last response' do
       stub_request.to_return(value1, value2)
-      expect(stub_request.response.evaluate).to eq(value1)
-      expect(stub_request.response.evaluate).to eq(value2)
-      expect(stub_request.response.evaluate).to eq(value2)
-      expect(stub_request.response.evaluate).to eq(value2)
+      expect(stub_request.response.call(request1)).to eq(value1)
+      expect(stub_request.response.call(request1)).to eq(value2)
+      expect(stub_request.response.call(request1)).to eq(value2)
+      expect(stub_request.response.call(request1)).to eq(value2)
+    end
+
+    it 'repeats running last response' do
+      stub_request.to_return(value1, value2) do |req|
+        case req
+        when request1; value1
+        when request2; value2
+        else; value3
+        end
+      end
+      expect(stub_request.response.call(request2)).to eq(value1)
+      expect(stub_request.response.call(request1)).to eq(value2)
+      expect(stub_request.response.call(request2)).to eq(value2)
+      expect(stub_request.response.call(request1)).to eq(value1)
+      expect(stub_request.response.call(request2)).to eq(value2)
     end
 
     context 'when not calling #to_return' do

--- a/spec/grpc_mock_spec.rb
+++ b/spec/grpc_mock_spec.rb
@@ -53,12 +53,40 @@ RSpec.describe GrpcMock do
       it { expect(client.send_message('hello!')).to eq(response) }
     end
 
+    context 'with to_return with block' do
+      let(:response) { Hello::HelloResponse.new(msg: 'test') }
+
+      before do
+        described_class.enable!
+        GrpcMock.stub_request('/hello.hello/Hello').to_return do |request|
+          expect(request.msg).to eq('hello!')
+          response
+        end
+      end
+
+      it { expect(client.send_message('hello!')).to eq(response) }
+    end
+
     context 'with to_raise' do
       let(:exception) { StandardError.new('message') }
 
       before do
         described_class.enable!
         GrpcMock.stub_request('/hello.hello/Hello').to_raise(exception)
+      end
+
+      it { expect { client.send_message('hello!') }.to raise_error(exception.class) }
+    end
+
+    context 'with to_return with raising block' do
+      let(:exception) { StandardError.new('message') }
+
+      before do
+        described_class.enable!
+        GrpcMock.stub_request('/hello.hello/Hello').to_return do |_request|
+          expect(request.msg).to eq('hello!')
+          raise exception
+        end
       end
 
       it { expect { client.send_message('hello!') }.to raise_error(exception.class) }


### PR DESCRIPTION
Both rspec-mocks and webmock have the ability to stub methods using blocks:

```ruby
# rspec-mocks
allow(dbl).to receive(:foo) { do_something }
# webmock
stub_request(:any, 'www.example.net').to_return { |request| {body: request.body} }
```

This is sometimes necessary (e.g. when we configure test in a way that the fixtures change over test runs, or when we want to build fakes instead of stubs), so I implemented the feature in this PR.