### PR TITLE
Suppress regexp warning

### DIFF
--- a/lib/grpc_mock/mocked_call.rb
+++ b/lib/grpc_mock/mocked_call.rb
@@ -36,7 +36,7 @@ module GrpcMock
 
         key = key.to_s
         # https://github.com/grpc/grpc/blob/v1.29.1/src/core/lib/surface/validate_metadata.cc#L61-L79
-        raise ArgumentError, "'#{key}' is an invalid header key" unless key.match?(/\A[a-z0-9-_.]+\z/) && key != ''
+        raise ArgumentError, "'#{key}' is an invalid header key" unless key.match?(/\A[a-z0-9\-_.]+\z/) && key != ''
         raise ArgumentError, "Header values must be of type string or array" unless value.is_a?(String) || value.is_a?(Array)
 
         Array(value).each do |elem|


### PR DESCRIPTION
It turned out https://github.com/ganmacs/grpc_mock/pull/10 produces the following warning:

```
warning: character class has '-' without escape: /\A[a-z0-9-_.]+\z/
```

This PR fixes it.