### PR TITLE
Return mocked operation instead of response when return_op is true

### DIFF
--- a/lib/grpc_mock/grpc_stub_adapter.rb
+++ b/lib/grpc_mock/grpc_stub_adapter.rb
@@ -5,8 +5,6 @@ require 'grpc_mock/errors'
 require 'grpc_mock/mocked_call'
 
 module GrpcMock
-  MockedOperation = Struct.new(:call, :metadata, :execute)
-
   class GrpcStubAdapter
     # To make hook point for GRPC::ClientStub
     # https://github.com/grpc/grpc/blob/bec3b5ada2c5e5d782dff0b7b5018df646b65cb0/src/ruby/lib/grpc/generic/service.rb#L150-L186
@@ -19,9 +17,15 @@ module GrpcMock
         mock = GrpcMock.stub_registry.response_for_request(method, request)
         if mock
           call = GrpcMock::MockedCall.new(metadata: metadata)
-          response = mock.evaluate(request, call.single_req_view)
-          return GRPC::MockedOperation.new(call, metadata, response) if return_op
-          response
+          if return_op
+            operation = call.operation
+            operation.define_singleton_method(:execute) do
+              mock.evaluate(request, call.single_req_view)
+            end
+            operation
+          else
+            mock.evaluate(request, call.single_req_view)
+          end
         elsif GrpcMock.config.allow_net_connect
           super
         else
@@ -39,9 +43,15 @@ module GrpcMock
         mock = GrpcMock.stub_registry.response_for_request(method, r)
         if mock
           call = GrpcMock::MockedCall.new(metadata: metadata)
-          response = mock.evaluate(r, call.multi_req_view)
-          return GrpcMock::MockedOperation.new(call, metadata, response) if return_op
-          response
+          if return_op
+            operation = call.operation
+            operation.define_singleton_method(:execute) do
+              mock.evaluate(r, call.multi_req_view)
+            end
+            operation
+          else
+            mock.evaluate(r, call.multi_req_view)
+          end
         elsif GrpcMock.config.allow_net_connect
           super
         else
@@ -56,10 +66,15 @@ module GrpcMock
 
         mock = GrpcMock.stub_registry.response_for_request(method, request)
         if mock
-          call = GrpcMock::MockedCall.new(metadata: metadata)
-          response = mock.evaluate(request, call.single_req_view)
-          return GrpcMock::MockedOperation.new(call, metadata, response) if return_op
-          response
+          if return_op
+            operation = call.operation
+            operation.define_singleton_method(:execute) do
+              mock.evaluate(request, call.single_req_view)
+            end
+            operation
+          else
+            mock.evaluate(request, call.single_req_view)
+          end
         elsif GrpcMock.config.allow_net_connect
           super
         else
@@ -75,9 +90,15 @@ module GrpcMock
         r = requests.to_a       # FIXME: this may not work
         mock = GrpcMock.stub_registry.response_for_request(method, r)
         if mock
-          response = mock.evaluate(r, nil) # FIXME: provide BidiCall equivalent
-          return GrpcMock::MockedOperation.new(call, metadata, response) if return_op
-          response
+          if return_op
+            operation = call.operation
+            operation.define_singleton_method(:execute) do
+              mock.evaluate(r, nil) # FIXME: provide BidiCall equivalent
+            end
+            operation
+          else
+            mock.evaluate(r, nil) # FIXME: provide BidiCall equivalent
+          end
         elsif GrpcMock.config.allow_net_connect
           super
         else

--- a/lib/grpc_mock/grpc_stub_adapter.rb
+++ b/lib/grpc_mock/grpc_stub_adapter.rb
@@ -5,7 +5,7 @@ require 'grpc_mock/errors'
 require 'grpc_mock/mocked_call'
 
 module GrpcMock
-  MockedOperation = Struct.new(:execute)
+  MockedOperation = Struct.new(:call, :metadata, :execute)
 
   class GrpcStubAdapter
     # To make hook point for GRPC::ClientStub
@@ -20,7 +20,7 @@ module GrpcMock
         if mock
           call = GrpcMock::MockedCall.new(metadata: metadata)
           response = mock.evaluate(request, call.single_req_view)
-          return GrpcMock::MockedOperation.new(response) if return_op
+          return GRPC::MockedOperation.new(call, metadata, response) if return_op
           response
         elsif GrpcMock.config.allow_net_connect
           super
@@ -40,7 +40,7 @@ module GrpcMock
         if mock
           call = GrpcMock::MockedCall.new(metadata: metadata)
           response = mock.evaluate(r, call.multi_req_view)
-          return GrpcMock::MockedOperation.new(response) if return_op
+          return GrpcMock::MockedOperation.new(call, metadata, response) if return_op
           response
         elsif GrpcMock.config.allow_net_connect
           super
@@ -58,7 +58,7 @@ module GrpcMock
         if mock
           call = GrpcMock::MockedCall.new(metadata: metadata)
           response = mock.evaluate(request, call.single_req_view)
-          return GrpcMock::MockedOperation.new(response) if return_op
+          return GrpcMock::MockedOperation.new(call, metadata, response) if return_op
           response
         elsif GrpcMock.config.allow_net_connect
           super
@@ -76,7 +76,7 @@ module GrpcMock
         mock = GrpcMock.stub_registry.response_for_request(method, r)
         if mock
           response = mock.evaluate(r, nil) # FIXME: provide BidiCall equivalent
-          return GrpcMock::MockedOperation.new(response) if return_op
+          return GrpcMock::MockedOperation.new(call, metadata, response) if return_op
           response
         elsif GrpcMock.config.allow_net_connect
           super

--- a/lib/grpc_mock/mocked_call.rb
+++ b/lib/grpc_mock/mocked_call.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'grpc'
+require 'grpc_mock/mocked_operation'
 
 module GrpcMock
   class MockedCall
@@ -17,6 +18,10 @@ module GrpcMock
 
     def single_req_view
       GRPC::ActiveCall::SingleReqView.new(self)
+    end
+
+    def operation
+      GrpcMock::MockedOperation.new(self, metadata, deadline)
     end
 
     private

--- a/lib/grpc_mock/mocked_operation.rb
+++ b/lib/grpc_mock/mocked_operation.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module GrpcMock
+  MockedOperation = Struct.new(:call, :metadata, :deadline)
+end

--- a/spec/grpc_mock/mocked_call_spec.rb
+++ b/spec/grpc_mock/mocked_call_spec.rb
@@ -126,4 +126,31 @@ RSpec.describe GrpcMock::MockedCall do
       }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#operation" do
+    let(:metadata) { { 'foo' => 'bar' } }
+    let(:deadline) { Time.now }
+    let(:mocked_call) { described_class.new(metadata: metadata, deadline: deadline) }
+    subject { mocked_call.operation }
+
+    it { is_expected.to be_a(GrpcMock::MockedOperation) }
+
+    describe "metadata" do
+      subject { mocked_call.operation.metadata }
+
+      it { is_expected.to eq(metadata) }
+    end
+
+    describe "call" do
+      subject { mocked_call.operation.call }
+
+      it { is_expected.to eq(mocked_call) }
+    end
+
+    describe "deadline" do
+      subject { mocked_call.operation.deadline }
+
+      it { is_expected.to eq(deadline) }
+    end
+  end
 end


### PR DESCRIPTION
I couldn't use mocking for Google API as described in README file.
Google uses [gapic-generator-ruby](https://github.com/googleapis/gapic-generator-ruby) and in [RPC call](https://github.com/googleapis/gapic-generator-ruby/blob/5bf8413245b45a07991991f344f84916978841d8/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb#L120) they take operation (which responds to `:execute`) first, then execute it, then and yield both `response` and `operation` to block.

So, I added case for `GrpcMock::GrpcStubAdapter` to return `GrpcMock::MockedOperation` struct when given `return_op` is `true`.

In didn't found specs for `GrpcMock::GrpcStubAdapter` module, so I didn't added specs for this case too.