### PR TITLE
Fix missing reference to `call`

### DIFF
--- a/lib/grpc_mock/grpc_stub_adapter.rb
+++ b/lib/grpc_mock/grpc_stub_adapter.rb
@@ -66,6 +66,7 @@ module GrpcMock
 
         mock = GrpcMock.stub_registry.response_for_request(method, request)
         if mock
+          call = GrpcMock::MockedCall.new(metadata: metadata)
           if return_op
             operation = call.operation
             operation.define_singleton_method(:execute) do


### PR DESCRIPTION
I believe that in [this commit](https://github.com/ganmacs/grpc_mock/commit/e2a87c397146a18417d1fb37eea6bd0382217d27), `#server_streamer` broke due to the deletion of [this line](https://github.com/ganmacs/grpc_mock/commit/e2a87c397146a18417d1fb37eea6bd0382217d27#diff-01a788ff2995a0ef4703d4501dab5b26f119527b1aa80661c790a6ac8fd0232aL59), my tests suddenly started to fail. I added back the instantiation and everything seems to be back to normal.