### PR TITLE
Fix typo in request_including_matcher.rb

### DIFF
--- a/lib/grpc_mock/matchers/request_including_matcher.rb
+++ b/lib/grpc_mock/matchers/request_including_matcher.rb
@@ -32,7 +32,7 @@ module GrpcMock
       end
 
       def inspect
-        "reqeust_including(#{@expected.inspect})"
+        "request_including(#{@expected.inspect})"
       end
     end
   end


### PR DESCRIPTION
Small typo fix in the `RequestIncludingMatcher`.