### PR TITLE
CI against Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR adds Ruby 3.3 to the test matrix to ensure to work the gem with it.