### PR TITLE
Option to allow localhost and allowlist

### DIFF
--- a/lib/grpc_mock/api.rb
+++ b/lib/grpc_mock/api.rb
@@ -15,8 +15,10 @@ module GrpcMock
       GrpcMock::Matchers::RequestIncludingMatcher.new(values)
     end
 
-    def disable_net_connect!
+    def disable_net_connect!(allow_localhost: false, allow: nil)
       GrpcMock.config.allow_net_connect = false
+      GrpcMock.config.allow_localhost = allow_localhost
+      GrpcMock.config.allow = allow
     end
 
     def allow_net_connect!

--- a/lib/grpc_mock/configuration.rb
+++ b/lib/grpc_mock/configuration.rb
@@ -2,10 +2,12 @@
 
 module GrpcMock
   class Configuration
-    attr_accessor :allow_net_connect
+    attr_accessor :allow_net_connect, :allow_localhost, :allow
 
     def initialize
       @allow_net_connect = true
+      @allow_localhost = false
+      @allow = nil
     end
   end
 end

--- a/spec/examples/hello/hello_client.rb
+++ b/spec/examples/hello/hello_client.rb
@@ -1,23 +1,26 @@
 require_relative './hello_services_pb'
 
 class HelloClient
-  def initialize
-    @client = Hello::Hello::Stub.new('localhost:8000', :this_channel_is_insecure)
+  def initialize(host = 'localhost:8000')
+    @client = Hello::Hello::Stub.new(host, :this_channel_is_insecure)
   end
 
-  def send_message(msg, client_stream: false, server_stream: false, metadata: {})
+  def send_message(msg, client_stream: false, server_stream: false, metadata: {}, timeout: 0.1)
+    options = { metadata: metadata }
+    options[:deadline] = Time.now + timeout if timeout
+
     if client_stream && server_stream
       m = Hello::HelloStreamRequest.new(msg: msg)
-      @client.hello_stream([m].to_enum, metadata: metadata)
+      @client.hello_stream([m].to_enum, **options)
     elsif client_stream
       m = Hello::HelloStreamRequest.new(msg: msg)
-      @client.hello_client_stream([m].to_enum, metadata: metadata)
+      @client.hello_client_stream([m].to_enum, **options)
     elsif server_stream
       m = Hello::HelloRequest.new(msg: msg)
-      @client.hello_server_stream(m, metadata: metadata)
+      @client.hello_server_stream(m, **options)
     else
       m = Hello::HelloRequest.new(msg: msg)
-      @client.hello(m, metadata: metadata)
+      @client.hello(m, **options)
     end
   end
 end

--- a/spec/rspec_spec.rb
+++ b/spec/rspec_spec.rb
@@ -97,4 +97,298 @@ RSpec.describe 'grpc_mock/rspec' do
       end
     end
   end
+
+  context 'disable_net_connect with exception for localhost' do
+    before do
+      GrpcMock.disable_net_connect!(allow_localhost: true)
+    end
+
+    context 'when request_response' do
+      it { expect { client.send_message('hello!') } .to raise_error(GRPC::Unavailable) }
+    end
+
+    context 'when server_stream' do
+      it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GRPC::Unavailable) }
+    end
+
+    context 'when client_stream' do
+      it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GRPC::Unavailable) }
+    end
+
+    context 'when bidi_stream' do
+      it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GRPC::Unavailable) }
+    end
+
+    context 'but client does not reference localhost' do
+      let(:client) do
+        HelloClient.new('example.com:8000')
+      end
+
+      context 'when request_response' do
+        it { expect { client.send_message('hello!') } .to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+
+      context 'when server_stream' do
+        it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+
+      context 'when client_stream' do
+        it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+
+      context 'when bidi_stream' do
+        it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+    end
+  end
+
+  context 'disable_net_connect with allow specified' do
+    before do
+      GrpcMock.disable_net_connect!(allow: allow_list)
+    end
+
+    let(:client) do
+      HelloClient.new('example.com:8000')
+    end
+
+    context 'as nil' do
+      let(:allow_list) { nil }
+
+      context 'when request_response' do
+        it { expect { client.send_message('hello!') } .to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+
+      context 'when server_stream' do
+        it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+
+      context 'when client_stream' do
+        it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+
+      context 'when bidi_stream' do
+        it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+    end
+
+    context 'as empty array' do
+      let(:allow_list) { [] }
+
+      context 'when request_response' do
+        it { expect { client.send_message('hello!') } .to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+
+      context 'when server_stream' do
+        it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+
+      context 'when client_stream' do
+        it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+
+      context 'when bidi_stream' do
+        it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+      end
+    end
+
+    context 'as string' do
+      let(:allow_list) { 'example.com' }
+
+      context 'when request_response' do
+        it { expect { client.send_message('hello!') } .to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when server_stream' do
+        it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when client_stream' do
+        it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when bidi_stream' do
+        it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'with a port' do
+        let(:allow_list) { 'example.com:8000' }
+
+        context 'when request_response' do
+          it { expect { client.send_message('hello!') } .to raise_error(GRPC::Unavailable) }
+        end
+
+        context 'when server_stream' do
+          it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GRPC::Unavailable) }
+        end
+
+        context 'when client_stream' do
+          it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GRPC::Unavailable) }
+        end
+
+        context 'when bidi_stream' do
+          it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GRPC::Unavailable) }
+        end
+      end
+
+      context 'with a non-matching port' do
+        let(:allow_list) { 'example.com:8888' }
+
+        context 'when request_response' do
+          it { expect { client.send_message('hello!') } .to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when server_stream' do
+          it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when client_stream' do
+          it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when bidi_stream' do
+          it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+      end
+
+      context 'that does not match' do
+        let(:allow_list) { 'exmple.com'}
+
+        context 'when request_response' do
+          it { expect { client.send_message('hello!') } .to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when server_stream' do
+          it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when client_stream' do
+          it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when bidi_stream' do
+          it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+      end
+    end
+
+    context 'as array of strings' do
+      let(:allow_list) { ['http://example.com', 'foo.com'] }
+
+      context 'when request_response' do
+        it { expect { client.send_message('hello!') } .to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when server_stream' do
+        it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when client_stream' do
+        it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when bidi_stream' do
+        it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'that does not match' do
+        let(:allow_list) { ['exmple.com', 'foo.com'] }
+
+        context 'when request_response' do
+          it { expect { client.send_message('hello!') } .to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when server_stream' do
+          it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when client_stream' do
+          it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when bidi_stream' do
+          it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+      end
+    end
+
+    context 'as array of procs' do
+      let(:allow_list) { [proc { |uri| uri.host.starts_with?('ex') }] }
+
+      context 'when request_response' do
+        it { expect { client.send_message('hello!') } .to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when server_stream' do
+        it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when client_stream' do
+        it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when bidi_stream' do
+        it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'that does not match' do
+        let(:allow_list) { [proc { |uri| uri.host.starts_with?('ax') }] }
+
+        context 'when request_response' do
+          it { expect { client.send_message('hello!') } .to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when server_stream' do
+          it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when client_stream' do
+          it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when bidi_stream' do
+          it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+      end
+    end
+
+    context 'as array of regex' do
+      let(:allow_list) { [/ex/, /foo/] }
+
+      context 'when request_response' do
+        it { expect { client.send_message('hello!') } .to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when server_stream' do
+        it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when client_stream' do
+        it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'when bidi_stream' do
+        it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GRPC::Unavailable) }
+      end
+
+      context 'that does not match' do
+        let(:allow_list) { [/ax/, /foo/] }
+
+        context 'when request_response' do
+          it { expect { client.send_message('hello!') } .to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when server_stream' do
+          it { expect { client.send_message('hello!', server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when client_stream' do
+          it { expect { client.send_message('hello!', client_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+
+        context 'when bidi_stream' do
+          it { expect { client.send_message('hello!', client_stream: true, server_stream: true) }.to raise_error(GrpcMock::NetConnectNotAllowedError) }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `disable_net_connect!` will block any outgoing requests. However, some development environments include core infrastructure which requires gRPC communication. For example, projects utilizing a Bigtable emulator that need to keep this dependency functioning as part of the local system while simultanesouly needing disable system-external gRPC calls.

This commit provides an option to allow localhost-like connections, and specify an allowlist of hosts for which gRPC requests should not be disabled. It shadows the pattern used by the Webmock Ruby library.